### PR TITLE
Correct model names and weapons order

### DIFF
--- a/src/data/models/aysa_drayce.json
+++ b/src/data/models/aysa_drayce.json
@@ -1,5 +1,5 @@
 {
-    "id": "aysa_drace",
+    "id": "aysa_drayce",
     "name": "Major Aysa Drayce",
     "factions": ["isa"],
     "type": "solo",

--- a/src/data/models/baron_mooregrave.json
+++ b/src/data/models/baron_mooregrave.json
@@ -15,8 +15,8 @@
         "boxes": 3
     },
     "weapons": [
-        "oblivion",
-        "magnum"
+        "magnum",
+        "oblivion"
     ],
     "advantages": [
         "weapon_expert"

--- a/src/data/models/index.js
+++ b/src/data/models/index.js
@@ -99,7 +99,7 @@ const modelsData = {
 	aurelion: aurelion,
 	automech: automech,
 	axel_for_hire: axel_for_hire,
-	aysa_drace: aysa_drace,
+	aysa_drayce: aysa_drayce,
 	baron_mooregrave: baron_mooregrave,
 	blast_shield: blast_shield,
 	carapax: carapax,

--- a/src/data/models/jax_redblade.json
+++ b/src/data/models/jax_redblade.json
@@ -15,8 +15,8 @@
         "boxes": 3
     },
     "weapons": [
-        "fusion_sword",
-        "magnum"
+        "magnum",
+        "fusion_sword"
     ],
     "advantages": [
         "weapon_expert"

--- a/src/data/models/paladin_commander.json
+++ b/src/data/models/paladin_commander.json
@@ -14,8 +14,8 @@
         "boxes": 2
     },
     "weapons": [
-        "fusion_sword",
-        "pulse_cannon"
+        "pulse_cannon",
+        "fusion_sword"
     ],
     "advantages": [
         "compound_armor"

--- a/src/data/models/quartermaster.json
+++ b/src/data/models/quartermaster.json
@@ -17,8 +17,8 @@
     },
     "weapons": [
         "assault_rifle_quartermaster",
-        "spiker",
-        "null_detonator"
+        "null_detonator",
+        "spiker"
     ],
     "special_rules": [
         "aegis_field",

--- a/src/data/models/voitek_sudal.json
+++ b/src/data/models/voitek_sudal.json
@@ -15,9 +15,9 @@
         "boxes": 3
     },
     "weapons": [
-        "combat_blade",
         "force_constrictor",
-        "null_detonator"
+        "null_detonator",
+        "combat_blade"
     ],
     "advantages": [
         "pathfinder",

--- a/src/data/weapons/gravitronic_lash.json
+++ b/src/data/weapons/gravitronic_lash.json
@@ -1,6 +1,6 @@
 {
-    "id": "gravitonic_lash",
-    "name": "Gravitonic Lash",
+    "id": "gravitronic_lash",
+    "name": "Gravitronic Lash",
     "point_cost": 1,
     "profiles": [{
         "type": "range", 

--- a/src/data/weapons/index.js
+++ b/src/data/weapons/index.js
@@ -242,7 +242,7 @@ const weaponsData = {
 	fusion_sword: fusion_sword,
 	fusion_torch: fusion_torch,
 	gate_crasher: gate_crasher,
-	gravitonic_lash: gravitonic_lash,
+	gravitronic_lash: gravitronic_lash,
 	grenade_launcher: grenade_launcher,
 	handgun: handgun,
 	harbinger_cannon: harbinger_cannon,


### PR DESCRIPTION
This pull request does two things:

1. It changes some remaining models and weapons ids and names (Major Aysa Drayce and Gravitronic Lash).
2. It reorders some model `weapons` to reflect the order on the Warcaster cards (Ranged weapons first, followed by melee weapons, each group ordered alphabetically). Affected models are Baron Mooregrave, Jax Redblade, The Quartermaster, and Voitek Sundal. With all of them being Wild Card Hero Solos, and all other models already adhering to the correct order, I assume this is an oversight and should be corrected. Also, it enables me to reproduce the `weapons` based on Wiki data deterministically.